### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ categories = ["command-line-interface"]
 readme = "README.md"
 
 [dependencies]
-rustyline = "6.0.0"
-url = { version = "2.0.0", optional = true }
+rustyline = "9.1.2"
+url = { version = "2.2.2", optional = true }
 
 [features]
 default = []

--- a/src/path.rs
+++ b/src/path.rs
@@ -25,7 +25,9 @@ struct FilenameHelper {
 }
 
 impl Helper for FilenameHelper {}
-impl rustyline::hint::Hinter for FilenameHelper {}
+impl rustyline::hint::Hinter for FilenameHelper {
+    type Hint = String;
+}
 impl rustyline::validate::Validator for FilenameHelper {}
 impl rustyline::highlight::Highlighter for FilenameHelper {}
 impl Completer for FilenameHelper {


### PR DESCRIPTION
The old version of nix used by this version of rustyline was vulnerable to [RUSTSEC-2021-0119](https://rustsec.org/advisories/RUSTSEC-2021-0119.html), and this made this crate fail `cargo audit`. After this is fixed, there should probably be a new release of promptly so crates using it as a dependency can use the fix.